### PR TITLE
feat: 향기 수동 매핑 로직 구현

### DIFF
--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/admin/AdminInitializer.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/admin/AdminInitializer.java
@@ -6,8 +6,11 @@ import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
 import deepscent_cnu.deepscent_cnu_api.auth.repository.MemberRepository;
 import deepscent_cnu.deepscent_cnu_api.auth.service.MemberService;
 import deepscent_cnu.deepscent_cnu_api.device_info.dto.request.DeviceRegisterRequest;
+import deepscent_cnu.deepscent_cnu_api.device_info.dto.request.RegisterSlotInfoRequest;
 import deepscent_cnu.deepscent_cnu_api.device_info.service.DeviceRegisterService;
+import deepscent_cnu.deepscent_cnu_api.device_info.service.SlotInfoService;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,16 +26,18 @@ public class AdminInitializer implements ApplicationRunner {
   private final MemberService memberService;
   private final MemberRepository memberRepository;
   private final DeviceRegisterService deviceRegisterService;
+  private final SlotInfoService slotInfoService;
   @Value("${admin.username}")
   private String username;
   @Value("${admin.password}")
   private String password;
 
   public AdminInitializer(MemberService memberService, MemberRepository memberRepository,
-      DeviceRegisterService deviceRegisterService) {
+      DeviceRegisterService deviceRegisterService, SlotInfoService slotInfoService) {
     this.memberService = memberService;
     this.deviceRegisterService = deviceRegisterService;
     this.memberRepository = memberRepository;
+    this.slotInfoService = slotInfoService;
   }
 
   @Override
@@ -46,6 +51,17 @@ public class AdminInitializer implements ApplicationRunner {
     for (int deviceNumber = 1; deviceNumber <= 3; deviceNumber++) {
       deviceRegisterService.registerDeviceId(member,
           new DeviceRegisterRequest(deviceNumber, deviceIds.get(deviceNumber - 1)));
+    }
+
+    List<String> scents = new ArrayList<>(
+        List.of("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"));
+    for (int deviceNumber = 1; deviceNumber <= 3; deviceNumber++) {
+      for (int fanNumber = 1; fanNumber <= 4; fanNumber++) {
+        int scentIdx = (deviceNumber - 1) * 4 + (fanNumber - 1);
+        slotInfoService.registerSlotInfo(
+            new RegisterSlotInfoRequest(memberResponse.id(), deviceNumber, fanNumber,
+                scents.get(scentIdx)));
+      }
     }
   }
 }

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/admin/AdminInitializer.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/admin/AdminInitializer.java
@@ -1,7 +1,7 @@
 package deepscent_cnu.deepscent_cnu_api.admin;
 
-import deepscent_cnu.deepscent_cnu_api.auth.dto.MemberResponse;
-import deepscent_cnu.deepscent_cnu_api.auth.dto.SignupRequest;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.request.SignupRequest;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.response.MemberResponse;
 import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
 import deepscent_cnu.deepscent_cnu_api.auth.repository.MemberRepository;
 import deepscent_cnu.deepscent_cnu_api.auth.service.MemberService;

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/controller/AuthController.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/controller/AuthController.java
@@ -1,15 +1,18 @@
 package deepscent_cnu.deepscent_cnu_api.auth.controller;
 
-import deepscent_cnu.deepscent_cnu_api.auth.dto.LoginRequest;
-import deepscent_cnu.deepscent_cnu_api.auth.dto.MemberResponse;
-import deepscent_cnu.deepscent_cnu_api.auth.dto.SignupRequest;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.request.LoginRequest;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.request.SignupRequest;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.response.MemberListResponse;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.response.MemberResponse;
 import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
 import deepscent_cnu.deepscent_cnu_api.auth.service.MemberService;
+import deepscent_cnu.deepscent_cnu_api.config.resolver.AdminToken;
 import deepscent_cnu.deepscent_cnu_api.config.resolver.AuthToken;
 import deepscent_cnu.deepscent_cnu_api.util.ApiResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,5 +44,10 @@ public class AuthController {
   public ResponseEntity<ApiResponse<Object>> withdraw(@AuthToken Member member) {
     memberService.deleteMember(member.getId());
     return ResponseEntity.ok(new ApiResponse<>(true, "회원 탈퇴가 완료되었습니다.", null));
+  }
+
+  @GetMapping("/member")
+  public ResponseEntity<MemberListResponse> getMemberList(@AdminToken Member member) {
+    return ResponseEntity.ok().body(memberService.getMemberAll());
   }
 }

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/controller/AuthController.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/controller/AuthController.java
@@ -2,17 +2,14 @@ package deepscent_cnu.deepscent_cnu_api.auth.controller;
 
 import deepscent_cnu.deepscent_cnu_api.auth.dto.request.LoginRequest;
 import deepscent_cnu.deepscent_cnu_api.auth.dto.request.SignupRequest;
-import deepscent_cnu.deepscent_cnu_api.auth.dto.response.MemberListResponse;
 import deepscent_cnu.deepscent_cnu_api.auth.dto.response.MemberResponse;
 import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
 import deepscent_cnu.deepscent_cnu_api.auth.service.MemberService;
-import deepscent_cnu.deepscent_cnu_api.config.resolver.AdminToken;
 import deepscent_cnu.deepscent_cnu_api.config.resolver.AuthToken;
 import deepscent_cnu.deepscent_cnu_api.util.ApiResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,10 +41,5 @@ public class AuthController {
   public ResponseEntity<ApiResponse<Object>> withdraw(@AuthToken Member member) {
     memberService.deleteMember(member.getId());
     return ResponseEntity.ok(new ApiResponse<>(true, "회원 탈퇴가 완료되었습니다.", null));
-  }
-
-  @GetMapping("/member")
-  public ResponseEntity<MemberListResponse> getMemberList(@AdminToken Member member) {
-    return ResponseEntity.ok().body(memberService.getMemberAll());
   }
 }

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/request/LoginRequest.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package deepscent_cnu.deepscent_cnu_api.auth.dto;
+package deepscent_cnu.deepscent_cnu_api.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/request/SignupRequest.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/request/SignupRequest.java
@@ -1,4 +1,4 @@
-package deepscent_cnu.deepscent_cnu_api.auth.dto;
+package deepscent_cnu.deepscent_cnu_api.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/response/MemberInfo.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/response/MemberInfo.java
@@ -1,0 +1,13 @@
+package deepscent_cnu.deepscent_cnu_api.auth.dto.response;
+
+import java.time.LocalDate;
+
+public record MemberInfo(
+    Long id,
+    String name,
+    LocalDate birthDate,
+    String phoneNumber,
+    String userName
+) {
+
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/response/MemberListResponse.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/response/MemberListResponse.java
@@ -1,0 +1,9 @@
+package deepscent_cnu.deepscent_cnu_api.auth.dto.response;
+
+import java.util.List;
+
+public record MemberListResponse(
+    List<MemberInfo> members
+) {
+
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/response/MemberResponse.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/dto/response/MemberResponse.java
@@ -1,4 +1,4 @@
-package deepscent_cnu.deepscent_cnu_api.auth.dto;
+package deepscent_cnu.deepscent_cnu_api.auth.dto.response;
 
 import java.time.LocalDate;
 

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/service/MemberService.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/auth/service/MemberService.java
@@ -1,8 +1,10 @@
 package deepscent_cnu.deepscent_cnu_api.auth.service;
 
-import deepscent_cnu.deepscent_cnu_api.auth.dto.LoginRequest;
-import deepscent_cnu.deepscent_cnu_api.auth.dto.MemberResponse;
-import deepscent_cnu.deepscent_cnu_api.auth.dto.SignupRequest;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.request.LoginRequest;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.request.SignupRequest;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.response.MemberInfo;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.response.MemberListResponse;
+import deepscent_cnu.deepscent_cnu_api.auth.dto.response.MemberResponse;
 import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
 import deepscent_cnu.deepscent_cnu_api.auth.repository.MemberRepository;
 import deepscent_cnu.deepscent_cnu_api.device_info.entity.DeviceInfo;
@@ -10,6 +12,7 @@ import deepscent_cnu.deepscent_cnu_api.device_info.repository.DeviceRegisterRepo
 import deepscent_cnu.deepscent_cnu_api.exception.ErrorCode;
 import deepscent_cnu.deepscent_cnu_api.exception.MemberException;
 import deepscent_cnu.deepscent_cnu_api.util.JwtTokenProvider;
+import java.util.List;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -94,5 +97,15 @@ public class MemberService {
   public Member findById(Long id) {
     return memberRepository.findById(id)
         .orElseThrow(() -> new MemberException(ErrorCode.USER_NOT_FOUND));
+  }
+
+  @Transactional(readOnly = true)
+  public MemberListResponse getMemberAll() {
+    List<MemberInfo> memberList = memberRepository.findAll().stream()
+        .map((member) -> new MemberInfo(
+            member.getId(), member.getName(), member.getBirthDate(), member.getPhoneNumber(),
+            member.getUsername())).toList();
+
+    return new MemberListResponse(memberList);
   }
 }

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/config/resolver/AdminToken.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/config/resolver/AdminToken.java
@@ -1,0 +1,14 @@
+package deepscent_cnu.deepscent_cnu_api.config.resolver;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AdminToken {
+
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/config/resolver/AdminTokenMethodArgumentResolver.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/config/resolver/AdminTokenMethodArgumentResolver.java
@@ -11,31 +11,34 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-public class AuthTokenMethodArgumentResolver implements HandlerMethodArgumentResolver {
+public class AdminTokenMethodArgumentResolver implements HandlerMethodArgumentResolver {
 
   private final MemberService memberService;
 
-  public AuthTokenMethodArgumentResolver(MemberService memberService) {
+  public AdminTokenMethodArgumentResolver(MemberService memberService) {
     this.memberService = memberService;
   }
 
   @Override
   public boolean supportsParameter(MethodParameter parameter) {
-    return parameter.hasParameterAnnotation(AuthToken.class)
-        && Member.class.isAssignableFrom(parameter.getParameterType());
+    return parameter.hasParameterAnnotation(AdminToken.class) && Member.class.isAssignableFrom(
+        parameter.getParameterType());
   }
 
   @Override
-  public Object resolveArgument(
-      MethodParameter parameter,
-      ModelAndViewContainer mavContainer,
-      NativeWebRequest webRequest,
-      WebDataBinderFactory binderFactory
-  ) {
+  public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
     HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
     Long memberId = (Long) request.getAttribute("memberId");
+
     if (memberId == null) {
       throw new MemberException(ErrorCode.TOKEN_REQUIRED);
+    }
+
+    Member member = memberService.findById(memberId);
+
+    if (!member.getUsername().equalsIgnoreCase("admin")) {
+      throw new MemberException(ErrorCode.NOT_ADMIN);
     }
 
     return memberService.findById(memberId);

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/config/resolver/ResolverConfig.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/config/resolver/ResolverConfig.java
@@ -22,8 +22,14 @@ public class ResolverConfig implements WebMvcConfigurer {
     return new AuthTokenMethodArgumentResolver(memberService);
   }
 
+  @Bean
+  public AdminTokenMethodArgumentResolver adminTokenMethodArgumentResolver() {
+    return new AdminTokenMethodArgumentResolver(memberService);
+  }
+
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
     resolvers.add(authTokenMethodArgumentResolver());
+    resolvers.add(adminTokenMethodArgumentResolver());
   }
 }

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/controller/DeviceRegisterController.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/controller/DeviceRegisterController.java
@@ -1,13 +1,19 @@
 package deepscent_cnu.deepscent_cnu_api.device_info.controller;
 
 import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
+import deepscent_cnu.deepscent_cnu_api.config.resolver.AdminToken;
 import deepscent_cnu.deepscent_cnu_api.config.resolver.AuthToken;
 import deepscent_cnu.deepscent_cnu_api.device_info.dto.request.DeviceRegisterRequest;
+import deepscent_cnu.deepscent_cnu_api.device_info.dto.request.RegisterSlotInfoRequest;
+import deepscent_cnu.deepscent_cnu_api.device_info.dto.request.TargetMemberIdRequest;
+import deepscent_cnu.deepscent_cnu_api.device_info.dto.response.CapsuleInfoResponse;
 import deepscent_cnu.deepscent_cnu_api.device_info.dto.response.DeviceInfoResponse;
 import deepscent_cnu.deepscent_cnu_api.device_info.service.DeviceRegisterService;
+import deepscent_cnu.deepscent_cnu_api.device_info.service.SlotInfoService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,9 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DeviceRegisterController {
 
   private final DeviceRegisterService deviceRegisterService;
+  private final SlotInfoService slotInfoService;
 
-  public DeviceRegisterController(DeviceRegisterService deviceRegisterService) {
+  public DeviceRegisterController(DeviceRegisterService deviceRegisterService,
+      SlotInfoService slotInfoService) {
     this.deviceRegisterService = deviceRegisterService;
+    this.slotInfoService = slotInfoService;
   }
 
   @PostMapping("/register")
@@ -33,5 +42,19 @@ public class DeviceRegisterController {
   @GetMapping
   public ResponseEntity<DeviceInfoResponse> getDeviceIdAll(@AuthToken Member member) {
     return ResponseEntity.ok().body(deviceRegisterService.getDeviceIdAll(member));
+  }
+
+  @PostMapping("/register-slot")
+  public ResponseEntity<Void> registerSlotInfo(@AdminToken Member member,
+      @RequestBody RegisterSlotInfoRequest request) {
+    slotInfoService.registerSlotInfo(request);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/get-slot/{targetMemberId}")
+  public ResponseEntity<CapsuleInfoResponse> getSlotInfoList(@AdminToken Member member,
+      @PathVariable(name = "targetMemberId") Long targetMemberId) {
+    return ResponseEntity.ok()
+        .body(slotInfoService.getSlotInfoList(new TargetMemberIdRequest(targetMemberId)));
   }
 }

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/dto/request/RegisterSlotInfoRequest.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/dto/request/RegisterSlotInfoRequest.java
@@ -1,0 +1,10 @@
+package deepscent_cnu.deepscent_cnu_api.device_info.dto.request;
+
+public record RegisterSlotInfoRequest(
+    Long targetMemberId,
+    Integer deviceNumber,
+    Integer fanNumber,
+    String scent
+) {
+
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/dto/request/TargetMemberIdRequest.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/dto/request/TargetMemberIdRequest.java
@@ -1,0 +1,7 @@
+package deepscent_cnu.deepscent_cnu_api.device_info.dto.request;
+
+public record TargetMemberIdRequest(
+    Long targetMemberId
+) {
+
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/dto/response/CapsuleInfo.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/dto/response/CapsuleInfo.java
@@ -1,0 +1,9 @@
+package deepscent_cnu.deepscent_cnu_api.device_info.dto.response;
+
+public record CapsuleInfo(
+    String scentName,
+    Integer deviceNumber,
+    Integer fanNumber
+) {
+
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/dto/response/CapsuleInfoResponse.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/dto/response/CapsuleInfoResponse.java
@@ -1,0 +1,9 @@
+package deepscent_cnu.deepscent_cnu_api.device_info.dto.response;
+
+import java.util.List;
+
+public record CapsuleInfoResponse(
+    List<CapsuleInfo> capsuleInfoList
+) {
+
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/entity/SlotInfo.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/entity/SlotInfo.java
@@ -1,0 +1,45 @@
+package deepscent_cnu.deepscent_cnu_api.device_info.entity;
+
+import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Entity
+public class SlotInfo {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(nullable = false)
+  private Member member;
+
+  @Getter
+  @Column(nullable = false)
+  private Integer deviceNumber;
+
+  @Getter
+  @Column(nullable = false)
+  private Integer fanNumber;
+
+  @Getter
+  @Column(nullable = false)
+  private String scent;
+
+  public SlotInfo() {
+  }
+
+  public SlotInfo(Member member, Integer deviceNumber, Integer fanNumber, String scent) {
+    this.member = member;
+    this.deviceNumber = deviceNumber;
+    this.fanNumber = fanNumber;
+    this.scent = scent;
+  }
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/repository/SlotInfoRepository.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/repository/SlotInfoRepository.java
@@ -1,0 +1,11 @@
+package deepscent_cnu.deepscent_cnu_api.device_info.repository;
+
+import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
+import deepscent_cnu.deepscent_cnu_api.device_info.entity.SlotInfo;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SlotInfoRepository extends JpaRepository<SlotInfo, Long> {
+
+  List<SlotInfo> findAllByMember(Member member);
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/service/SlotInfoService.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/device_info/service/SlotInfoService.java
@@ -1,0 +1,56 @@
+package deepscent_cnu.deepscent_cnu_api.device_info.service;
+
+import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
+import deepscent_cnu.deepscent_cnu_api.auth.repository.MemberRepository;
+import deepscent_cnu.deepscent_cnu_api.device_info.dto.request.RegisterSlotInfoRequest;
+import deepscent_cnu.deepscent_cnu_api.device_info.dto.request.TargetMemberIdRequest;
+import deepscent_cnu.deepscent_cnu_api.device_info.dto.response.CapsuleInfo;
+import deepscent_cnu.deepscent_cnu_api.device_info.dto.response.CapsuleInfoResponse;
+import deepscent_cnu.deepscent_cnu_api.device_info.entity.SlotInfo;
+import deepscent_cnu.deepscent_cnu_api.device_info.repository.SlotInfoRepository;
+import deepscent_cnu.deepscent_cnu_api.exception.ErrorCode;
+import deepscent_cnu.deepscent_cnu_api.exception.MemberException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SlotInfoService {
+
+  private final SlotInfoRepository slotInfoRepository;
+  private final MemberRepository memberRepository;
+
+  public SlotInfoService(SlotInfoRepository slotInfoRepository, MemberRepository memberRepository) {
+    this.slotInfoRepository = slotInfoRepository;
+    this.memberRepository = memberRepository;
+  }
+
+  public void registerSlotInfo(RegisterSlotInfoRequest request) {
+    Member targetMember = memberRepository.findById(request.targetMemberId())
+        .orElseThrow(() -> new MemberException(
+            ErrorCode.TARGET_MEMBER_NOT_FOUND));
+
+    slotInfoRepository.save(
+        new SlotInfo(targetMember, request.deviceNumber(), request.fanNumber(), request.scent()));
+  }
+
+  public CapsuleInfoResponse getSlotInfoList(TargetMemberIdRequest request) {
+    List<CapsuleInfo> capsuleInfoList = new ArrayList<>(Collections.nCopies(12, null));
+    Member targetMember = memberRepository.findById(request.targetMemberId())
+        .orElseThrow(() -> new MemberException(
+            ErrorCode.TARGET_MEMBER_NOT_FOUND));
+    List<SlotInfo> slotInfoList = slotInfoRepository.findAllByMember(targetMember);
+
+    for (SlotInfo slotInfo : slotInfoList) {
+      Integer deviceNumber = slotInfo.getDeviceNumber();
+      Integer fanNumber = slotInfo.getFanNumber();
+      String scent = slotInfo.getScent();
+      int slotInfoListIdx = (deviceNumber - 1) * 4 + (fanNumber - 1);
+
+      capsuleInfoList.set(slotInfoListIdx, new CapsuleInfo(scent, deviceNumber, fanNumber));
+    }
+
+    return new CapsuleInfoResponse(capsuleInfoList);
+  }
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/ErrorCode.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
   INVALID_INPUT("입력값이 유효하지 않습니다."),
   TOKEN_REQUIRED("인증 토큰이 필요합니다."),
   INVALID_TOKEN("유효하지 않은 토큰입니다."),
-  UNEXPECTED_ERROR("예상치 못한 오류가 발생하였습니다.");
+  UNEXPECTED_ERROR("예상치 못한 오류가 발생하였습니다."),
+  NOT_ADMIN("관리자 계정만 접근이 가능합니다.");
 
   private final String message;
 

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/ErrorCode.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/ErrorCode.java
@@ -8,7 +8,8 @@ public enum ErrorCode {
   TOKEN_REQUIRED("인증 토큰이 필요합니다."),
   INVALID_TOKEN("유효하지 않은 토큰입니다."),
   UNEXPECTED_ERROR("예상치 못한 오류가 발생하였습니다."),
-  NOT_ADMIN("관리자 계정만 접근이 가능합니다.");
+  NOT_ADMIN("관리자 계정만 접근이 가능합니다."),
+  TARGET_MEMBER_NOT_FOUND("타겟 사용자 정보가 존재하지 않습니다.");
 
   private final String message;
 

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/GlobalExceptionHandler.java
@@ -46,6 +46,13 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(exceptionResponse, HttpStatus.NOT_FOUND);
   }
 
+  @ExceptionHandler(value = MemberException.class)
+  public ResponseEntity<ExceptionResponse> handleMemberException(
+      MemberException e) {
+    ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage());
+    return new ResponseEntity<>(exceptionResponse, HttpStatus.UNAUTHORIZED);
+  }
+
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<Object>> handleGeneralException(Exception ex) {
     ex.printStackTrace();

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/GlobalExceptionHandler.java
@@ -53,6 +53,13 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(exceptionResponse, HttpStatus.UNAUTHORIZED);
   }
 
+  @ExceptionHandler(value = SlotMappingException.class)
+  public ResponseEntity<ExceptionResponse> handleSlotMappingException(
+      SlotMappingException e) {
+    ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage());
+    return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+  }
+
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<Object>> handleGeneralException(Exception ex) {
     ex.printStackTrace();

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/SlotMappingException.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/exception/SlotMappingException.java
@@ -1,0 +1,8 @@
+package deepscent_cnu.deepscent_cnu_api.exception;
+
+public class SlotMappingException extends RuntimeException {
+
+  public SlotMappingException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/openai/MemoryRecallRound.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/openai/MemoryRecallRound.java
@@ -1,6 +1,5 @@
 package deepscent_cnu.deepscent_cnu_api.openai;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import deepscent_cnu.deepscent_cnu_api.auth.entity.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -50,7 +49,7 @@ public class MemoryRecallRound {
   @OneToMany(
       mappedBy = "memoryRecallRound",
       cascade = CascadeType.ALL,
-      orphanRemoval = true,fetch = FetchType.LAZY)
+      orphanRemoval = true, fetch = FetchType.LAZY)
   private List<UserChatMemory> messages = new ArrayList<>();
 
 }

--- a/src/main/java/deepscent_cnu/deepscent_cnu_api/openai/UserChatMemory.java
+++ b/src/main/java/deepscent_cnu/deepscent_cnu_api/openai/UserChatMemory.java
@@ -1,7 +1,6 @@
 package deepscent_cnu.deepscent_cnu_api.openai;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,8 @@ spring.profiles.active=api
 langchain4j.open-ai.chat-model.log-requests=true
 langchain4j.open-ai.chat-model.log-responses=true
 logging.level.dev.langchain4j=DEBUG
-spring.servlet.multipart.max-file-size=100MB
-spring.servlet.multipart.max-request-size=100MB
+spring.servlet.multipart.max-file-size=200MB
+spring.servlet.multipart.max-request-size=200MB
 # Secret Config
 spring.config.import=application-secret.properties
 


### PR DESCRIPTION
# 구현

- 기존의 전체 향기 조회 API, 일반 후각 훈련용 정답 향기 4개 선별 로직에 향기 수동 매핑 로직을 반영함
- 관리자 페이지에서 쓰일 service layer 함수들을 구현함
- 관리자 계정 검증을 위한 어노테이션과 리졸버를 구현함

<br/>
<br/>

# 관리자 페이지 로직 구상

- 1 depth : 관리자 로그인 페이지
  - 관리자 계정으로만 로그인 가능함
  - 로그인 성공 시, 관리자 계정 액세스 토큰을 받음 (관리자 페이지에서 API를 호출할 때 쓰이므로 프론트 측에서 갖고 있어야 함)
- 2 depth : 향기 수동 매핑 페이지
  - 유저 목록 조회 영역
    - 유저 정보 리스트 조회 API를 통해, 유저 정보를 쭉 띄움. 이를 통해 수동 향기 매핑을 하고 싶은 타겟 사용자의 PK ID 값을 확인 가능
  - 향기 매핑 정보 입력 영역
    - 타겟 유저 ID를 입력하는 인풋 박스가 하나 있고, 향기 이름을 입력하는 인풋 박스가 각 슬롯 별로 총 12개가 있음
    - 등록 버튼을 누르면, 타겟 유저 ID에 대해, 하나의 슬롯 정보 매핑을 수행함. 즉 12개를 각각 따로 입력 및 등록 버튼을 눌러주면 됨 (기기 등록 페이지랑 비슷한 느낌)
    - 현재 등록되어 있는 향기 이름 텍스트필드가 있고, 이건 페이지 최초 진입 시 타겟 사용자 향기 전체 조회 API를 호출해서 채워주면 됨

<br/>
<br/>

# 민지님 구현 필요한 부분

- 타임리프 뷰
- 컨트롤러

<br/>
<br/>

# 민지님 구현 시 필요하실 service layer 함수들
- 로그인을 제외한 모든 관리자 페이지에서의 API들은 관리자 계정인지 검증이 필요한데, 이를 위해 컨트롤러 메소드들 만드실 때 AdminToken 어노테이션 쓰시면 됩니다
- MemberService의 getMemberAll (모든 유저 정보 조회)
- SlotInfoService의 registerSlotInfo (특정 타겟 사용자의 향기 정보 1개를 수동 매핑)
- SlotInfoService의 getSlotInfoList (특정 타겟 사용자의 향기 수동 매핑 정보 전체 조회)
- AdminInitializer에서 서버 실행 시 자동으로 관리자 계정의 수동 향기 매핑을 A~L 알파벳으로 실행하는 부분이 있는데 혹시나 참고 필요하실 수도 있을 것 같아 말씀드려요

<br/>
<br/>

## 기본적인 구상을 이런 식으로 해두고 백엔드 작업을 했는데, 혹시 로직 변경을 원하시는 부분이나 제 구현 파트에서 궁금하신 부분이 있으시다면 편하게 말씀 주세요!